### PR TITLE
Remove .travis.yml from project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,0 @@
-language: java
-jdk:
-  - openjdk12


### PR DESCRIPTION
This commit removes the .travis.yml file from the project root, as CI is
being shifted to github actions.