### PR TITLE
Add github actions badge to README.md

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,4 +1,4 @@
-name: Compile Project
+name: compile
 
 on: [push]
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # idonis
 
-[![Build](https://travis-ci.org/LynxPlay/idonis.svg?branch=master)](https://travis-ci.org/LynxPlay/idonis)
+[![Build](https://github.com/lynxplay/idonis/workflows/compile/badge.svg?branch=master)](https://github.com/lynxplay/idonis/actions?workflow=compile)
 
 A really small SQL script caching framework to store complex SQL statements outside of java code.
 


### PR DESCRIPTION
This commit simply adds the github actions badge for the compile
workflow to the README.md file to represent the current state of the
project and if it is compiling or not.